### PR TITLE
Use `self.log.info` instead of `self.log.error`

### DIFF
--- a/jupyterlab_magic_wand/extension.py
+++ b/jupyterlab_magic_wand/extension.py
@@ -30,7 +30,7 @@ class AIMagicExtension(ExtensionApp):
             try:
                 agent = eps.load()
                 self.agents[agent.name] = agent
-                self.log.error(f"Successfully loaded workflow: {agent.name}")
+                self.log.info(f"Successfully loaded workflow: {agent.name}")
             except Exception as err:
                 self.log.error(err)
                 self.log.error(f"Unable to load {agent.name}")


### PR DESCRIPTION
As it otherwise logs the "Successfully loaded workflow" as an error, which may be misleading:

![image](https://github.com/user-attachments/assets/a3218fbc-fede-42f8-9b18-ad30bf7dc81c)
